### PR TITLE
Replace deprecated Tensor.data<T> to data_ptr<T>

### DIFF
--- a/launcher/Model-DNN.cpp
+++ b/launcher/Model-DNN.cpp
@@ -18,7 +18,7 @@ namespace pytorch {
         vector<torch::jit::IValue> inputTensor;
         inputTensor.push_back(inputVector);
         at::Tensor outputTensor = this -> module -> forward(inputTensor).toTensor();
-        vector<float> outputVector(outputTensor.data<float>(), outputTensor.data<float>() + outputTensor.numel());
+        vector<float> outputVector(outputTensor.data_ptr<float>(), outputTensor.data_ptr<float>() + outputTensor.numel());
         return outputVector;
     }
 

--- a/launcher/Model-RNN.cpp
+++ b/launcher/Model-RNN.cpp
@@ -18,7 +18,7 @@ namespace pytorch {
         vector<torch::jit::IValue> inputTensor;
         inputTensor.push_back(inputVector);
         at::Tensor outputTensor = this -> module -> forward(inputTensor).toTensor();
-        vector<float> outputVector(outputTensor.data<float>(), outputTensor.data<float>() + outputTensor.numel());
+        vector<float> outputVector(outputTensor.data_ptr<float>(), outputTensor.data_ptr<float>() + outputTensor.numel());
         return outputVector;
     }
 


### PR DESCRIPTION
Using Tensor.data<T> is deprecated by PyTorch, and using Tensor.data_ptr<T> is recommended.

This commit is including function replacements for every `Model-*.cpp` files, which include Tensor.data declarations.

https://github.com/pytorch/pytorch/blob/4e21157e01e07202b91274d19c1fb2849977d9e0/aten/src/ATen/templates/TensorBody.h#L310